### PR TITLE
Updates routing scheme

### DIFF
--- a/onyx_extension/handlers.py
+++ b/onyx_extension/handlers.py
@@ -1,6 +1,7 @@
 import os
 import json
 import re
+import requests
 import tempfile
 from pathlib import Path
 
@@ -8,18 +9,6 @@ from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 import tornado
 import boto3
-
-
-class RouteHandler(APIHandler):
-    # The following decorator should be present on all verb methods (head, get, post,
-    # patch, put, delete, options) to ensure only authorized user can request the
-    # Jupyter server
-    @tornado.web.authenticated
-    def get(self):
-        self.finish(json.dumps({
-            "domain": os.environ.get('ONYX_DOMAIN', '*Unknown*').strip('/'),
-            "token": os.environ.get('ONYX_TOKEN', '*Unknown*')
-        }))
 
 class S3ViewHandler(APIHandler):
 
@@ -40,9 +29,6 @@ class S3ViewHandler(APIHandler):
             s3_object.download_fileobj(fp)
         return f'./tmp/{o}'    
 
-    # The following decorator should be present on all verb methods (head, get, post,
-    # patch, put, delete, options) to ensure only authorized user can request the
-    # Jupyter server
     @tornado.web.authenticated
     def get(self):
         try:
@@ -60,18 +46,35 @@ class S3ViewHandler(APIHandler):
 
 
 
+class RedirectingRouteHandler(APIHandler):
+    @tornado.web.authenticated
+    def get(self):
+        try:
+            
+            domain = os.environ.get('ONYX_DOMAIN', '*Unknown*').strip('/')
+            token = os.environ.get('ONYX_TOKEN', '*Unknown*')
+            route_extension = self.get_query_argument("route")
+            route = f"{domain}/{route_extension}"
+            r= requests.get(route, headers={"Authorization": f"Token {token}"})
+            self.finish(r.json())
+        except Exception as e:
+            self.finish(json.dumps({
+                "exception": e
+            }))
+
 
 def setup_handlers(web_app):
     tempfile.mkdtemp()
     host_pattern = ".*$"
 
     base_url = web_app.settings["base_url"]
-    # Prepend the base_url so that it works in a JupyterHub setting
-    route_pattern = url_path_join(base_url, "onyx-extension", "settings")
-    handlers = [(route_pattern, RouteHandler)]
-    web_app.add_handlers(host_pattern, handlers)
 
     route_pattern = url_path_join(base_url, "onyx-extension", "s3")
     handlers = [(route_pattern, S3ViewHandler)]
+    web_app.add_handlers(host_pattern, handlers)
+
+    
+    route_pattern = url_path_join(base_url, "onyx-extension", "reroute")
+    handlers = [(route_pattern, RedirectingRouteHandler)]
     web_app.add_handlers(host_pattern, handlers)
 

--- a/onyx_extension/handlers.py
+++ b/onyx_extension/handlers.py
@@ -56,7 +56,7 @@ class RedirectingRouteHandler(APIHandler):
             route_extension = self.get_query_argument("route")
             route = f"{domain}/{route_extension}"
             r= requests.get(route, headers={"Authorization": f"Token {token}"})
-            self.finish(r.json())
+            self.finish(r.content)
         except Exception as e:
             self.finish(json.dumps({
                 "exception": e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "onyx_extension",
-    "version": "0.4.12",
+    "version": "0.5.1",
     "description": "A minimal JupyterLab extension with backend and frontend parts.",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@jupyterlab/htmlviewer": "^4.2.1",
         "@jupyterlab/launcher": "^4.0.0",
         "@jupyterlab/services": "^7.0.0",
-        "climb-onyx-ui": "^0.7.1"
+        "climb-onyx-ui": "^0.8.0"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,16 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import Onyx from 'climb-onyx-ui';
 
 export class ReactAppWidget extends ReactWidget {
-  constructor(route: (path: string) => Object| string, s3: (path: string) => void) {
+  constructor(route: (route: string)=> Promise<Response>, s3: (path: string) => void) {
     super();
     this.routeHandler = route;
     this.s3PathHandler= s3;
   }
 
-  routeHandler: (path: string) => Object|string;
+  routeHandler: (route: string)=> Promise<Response>;
   s3PathHandler: (path: string) => void;
 
   render(): JSX.Element {
-    return <Onyx routeHandler={this.routeHandler} s3PathHandler={this.s3PathHandler} />;
+    return <Onyx httpPathHandler={this.routeHandler} s3PathHandler={this.s3PathHandler} />;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,18 +4,16 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import Onyx from 'climb-onyx-ui';
 
 export class ReactAppWidget extends ReactWidget {
-  constructor(dom: string, tok: string, s3: (path: string) => void) {
+  constructor(route: (path: string) => Object| string, s3: (path: string) => void) {
     super();
-    this.domain = dom;
-    this.token = tok;
+    this.routeHandler = route;
     this.s3PathHandler= s3;
   }
 
-  domain: string;
-  token: string;
+  routeHandler: (path: string) => Object|string;
   s3PathHandler: (path: string) => void;
 
   render(): JSX.Element {
-    return <Onyx domain={this.domain} token={this.token} s3PathHandler={this.s3PathHandler} />;
+    return <Onyx routeHandler={this.routeHandler} s3PathHandler={this.s3PathHandler} />;
   }
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -48,3 +48,30 @@ export async function requestAPI<T>(
 
   return data;
 }
+
+
+export async function requestAPIResponse(
+  endPoint = '',
+  init: RequestInit = {},
+  param: [string, string] = ['', '']
+): Promise<Response> {
+  // Make request to Jupyter API
+  const settings = ServerConnection.makeSettings();
+
+  const requestUrl = URLExt.join(settings.baseUrl, 'onyx-extension', endPoint);
+
+  let url = new URL(requestUrl);
+  if (param[0] != '') url.searchParams.append(param[0], param[1]);
+
+  let response: Response;
+  try {
+    response = await ServerConnection.makeRequest(
+      url.toString(),
+      init,
+      settings
+    );
+  } catch (error) {
+    throw new ServerConnection.NetworkError(error as any);
+  }
+  return response;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
     const s3_command = 's3_onyx_extension';
     const category = 'Onyx';
 
-    let domain: string;
-    let token: string;
 
     const s3_open_function = (s3_link: string) => {
       requestAPI<any>('s3', {}, ['s3location', s3_link])
@@ -83,16 +81,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
         });
     };
 
-    requestAPI<any>('settings')
-      .then(data => {
-        domain = data['domain'];
-        token = data['token'];
-      })
-      .catch(reason => {
-        console.error(
-          `The onyx_extension server extension appears to be missing.\n${reason}`
-        );
-      });
+    const routeHandler = async (route: string): Promise<any> => {
+      return requestAPI<any>('reroute', {}, ['route', route]);
+    };
+
+    routeHandler('projects/')
 
     // Create a single widget
     let widget: MainAreaWidget<ReactAppWidget>;
@@ -103,7 +96,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       icon: chatIcon,
       execute: () => {
         if (!widget || widget.disposed) {
-          const content = new ReactAppWidget(domain, token, s3_open_function);
+          const content = new ReactAppWidget(routeHandler, s3_open_function);
           content.addClass('onyx-Widget');
           widget = new MainAreaWidget({ content });
           widget.title.label = 'Onyx';

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { HTMLViewer, IHTMLViewerTracker } from '@jupyterlab/htmlviewer';
 
 import { ILauncher } from '@jupyterlab/launcher';
 
-import { requestAPI } from './handler';
+import { requestAPI, requestAPIResponse } from './handler';
 import { ReactAppWidget } from './App';
 import { chatIcon } from './icon';
 import { Widget } from '@lumino/widgets';
@@ -81,11 +81,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
         });
     };
 
-    const routeHandler = async (route: string): Promise<any> => {
-      return requestAPI<any>('reroute', {}, ['route', route]);
+    const routeHandler = async (route: string): Promise<Response> => {
+      return requestAPIResponse('reroute', {}, ['route', route]);
     };
-
-    routeHandler('projects/')
 
     // Create a single widget
     let widget: MainAreaWidget<ReactAppWidget>;


### PR DESCRIPTION
Instead of passing a token and domain into the widget, we offer a service to reroute requests and return the result. This means that juppyterlap makes the requests and they are not blocked by security defences.