### PR TITLE
Fixing header spacing issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "climb-onyx-gui-extension",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "description": "JupyterLab extension for the Onyx Graphical User Interface",
     "keywords": [
         "gui",

--- a/style/base.css
+++ b/style/base.css
@@ -6,4 +6,5 @@
 
 .onyx-Widget {
   overflow: auto;
+  contain: strict;
 }


### PR DESCRIPTION
- The Onyx header sits weirdly in Jupyterlab 3, but is fine in Jupyterlab 4. The only major difference in the wrapping container I can see is a missing `contains: strict` so hopefully this works...