### PR TITLE
Updated Onyx GUI from 0.14.2 to 0.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "climb-onyx-gui-extension",
-    "version": "0.11.2",
+    "version": "0.12.0",
     "description": "JupyterLab extension for the Onyx Graphical User Interface",
     "keywords": [
         "gui",
@@ -74,7 +74,7 @@
         "@jupyterlab/htmlviewer": "^3.6.1 || ^4.2.1",
         "@jupyterlab/launcher": "^3.6.1 || ^4.0.0",
         "@jupyterlab/services": "^6.6.1 || ^7.0.0",
-        "climb-onyx-gui": "^0.14.2",
+        "climb-onyx-gui": "^0.15.1",
         "react": "^17.0.1 || ^18.2.0",
         "react-dom": "^17.0.1 || ^18.2.0",
         "webpack": "^5.92.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,7 +2201,7 @@ __metadata:
     "@types/react-addons-linked-state-mixin": ^0.14.22
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    climb-onyx-gui: ^0.14.2
+    climb-onyx-gui: ^0.15.1
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
@@ -2225,9 +2225,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"climb-onyx-gui@npm:^0.14.2":
-  version: 0.14.2
-  resolution: "climb-onyx-gui@npm:0.14.2"
+"climb-onyx-gui@npm:^0.15.1":
+  version: 0.15.1
+  resolution: "climb-onyx-gui@npm:0.15.1"
   dependencies:
     "@ag-grid-community/client-side-row-model": ^32.2.0
     "@ag-grid-community/core": ^32.2.0
@@ -2247,7 +2247,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 6d7973b5045140da49a1aeaf25ad22c07294d424f6629f8311b67a24527175fe8acf7478b53c9812a32dce9a49daf3eadb8daf06807fd13af621563f69dba65d
+  checksum: e283b369b49b31e29e5c05f8afdfc17622276ac36c5f598b3f48b812f348b902b0b46efca959359575d3020fa09555e11f41c026cefa563717452c083aebc977
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Updated Onyx GUI Changes 

* Enabled scrolling of details without scrolling the whole thing by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/86
* Enable scrolling record/analysis details while maintaining sidebar position in data panel by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/87
* Better lazy loading, cleaner tab transitions by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/90
* Landing page, Project Tabs, improved loading displays by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/91
* Remove all transforms button by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/92
* Landing page, Project Tabs, improved loading displays, pagination optimisations by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/93
* Columns modal by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/94
* Improved type system and tab state by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/95
* Recently viewed, graph range selectors by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/96
* Column selector modal, recently viewed, graph date range selectors by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/97
* CLI command copy button by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/98
* Copy Onyx CLI Command Button by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/99
* Default search fields, resize bar, improved search by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/100
* Bug fix: calculate resize slider position from widget container's position, not absolute viewport position by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/102
* Fixing repository url by @tombch in https://github.com/CLIMB-TRE/onyx-gui/pull/103
