### PR TITLE
Fixed widget loading behaviour, added dynamic title setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "climb-onyx-gui-extension",
-    "version": "0.12.1",
+    "version": "0.12.2",
     "description": "JupyterLab extension for the Onyx Graphical User Interface",
     "keywords": [
         "gui",
@@ -74,7 +74,7 @@
         "@jupyterlab/htmlviewer": "^3.6.1 || ^4.2.1",
         "@jupyterlab/launcher": "^3.6.1 || ^4.0.0",
         "@jupyterlab/services": "^6.6.1 || ^7.0.0",
-        "climb-onyx-gui": "^0.15.3",
+        "climb-onyx-gui": "^0.15.4",
         "react": "^17.0.1 || ^18.2.0",
         "react-dom": "^17.0.1 || ^18.2.0",
         "webpack": "^5.92.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,8 +188,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
           app.shell.add(widget, 'main');
         }
 
-        // Activate the widget
+        // Activate and return the widget
         app.shell.activateById(widget.id);
+        return widget;
       }
     });
 

--- a/src/onyxWidget.tsx
+++ b/src/onyxWidget.tsx
@@ -73,6 +73,11 @@ export class OnyxWidget extends ReactWidget {
     this._save(stateKey, value);
   }
 
+  // Set the title of the widget
+  setTitle = (title: string): void => {
+    this.title.label = title;
+  };
+
   render(): JSX.Element {
     return (
       <Onyx
@@ -82,6 +87,7 @@ export class OnyxWidget extends ReactWidget {
         extVersion={this.version}
         getItem={this.getItem.bind(this)}
         setItem={this.setItem.bind(this)}
+        setTitle={this.setTitle.bind(this)}
       />
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,7 +2201,7 @@ __metadata:
     "@types/react-addons-linked-state-mixin": ^0.14.22
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    climb-onyx-gui: ^0.15.3
+    climb-onyx-gui: ^0.15.4
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
@@ -2225,9 +2225,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"climb-onyx-gui@npm:^0.15.3":
-  version: 0.15.3
-  resolution: "climb-onyx-gui@npm:0.15.3"
+"climb-onyx-gui@npm:^0.15.4":
+  version: 0.15.4
+  resolution: "climb-onyx-gui@npm:0.15.4"
   dependencies:
     "@ag-grid-community/client-side-row-model": ^32.2.0
     "@ag-grid-community/core": ^32.2.0
@@ -2247,7 +2247,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 05005e80b2ada76b433ad8faeeb40d36098477f873cb68132ffd39bdaf9582cab64acb700b244bcfeb9001f96f80f53d5b34e803de5fa5e3f16d791d04225ef2
+  checksum: bc147b1ddcde57b42b8f7281ad25f8a38951fb4826316d23e0dae9b8d3544b252543cd4c2b2ff0283b86882416bb9982af7d8267a576973c296e8a87e454558e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- The `execute` function for the Onyx command now correctly returns the widget, allowing the launcher to be replaced in-place (i.e. the same behaviour as terminals etc)
- Provided handler `setTitle` for Onyx GUI `0.15.4` to use to dynamically update the widget title based on the active tab state within Onyx 