### PR TITLE
Using tornado `AsyncHTTPClient` to prevent jupyterlab server blocking by Onyx

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "^5.0.2",
+        "typescript": "~5.7.0",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "~5.7.0",
+        "typescript": "^5.0.2",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "~5.0.2",
+        "typescript": "~5.7.0",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,7 +2228,7 @@ __metadata:
     stylelint-config-standard: ^34.0.0
     stylelint-csstree-validator: ^3.0.0
     stylelint-prettier: ^4.0.0
-    typescript: ~5.0.2
+    typescript: ~5.7.0
     webpack: ^5.92.0
     yjs: ^13.5.0
   languageName: unknown
@@ -6133,23 +6133,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.2":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:~5.7.0":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: 6c38b1e989918e576f0307e6ee013522ea480dfce5f3ca85c9b2d8adb1edeffd37f4f30cd68de0c38a44563d12ba922bdb7e36aa2dac9c51de5d561e6e9a2e9c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+"typescript@patch:typescript@~5.7.0#~builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#~builtin<compat/typescript>::version=5.7.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: 633cd749d6cd7bc842c6b6245847173bba99742a60776fae3c0fbcc0d1733cd51a733995e5f4dadd8afb0e64e57d3c7dbbeae953a072ee303940eca69e22f311
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- The current Onyx extension occasionally blocks other Jupyterlab requests. 
- After some bug hunting, this was found to be due to the `RedirectingRouteHandler` using a synchronous `requests.get` call. This blocks all other tornado (the underlying server for Jupyter server) requests due to the tornado server using a single threaded event loop, intended primarily for asynchronous non-blocking operations: https://www.tornadoweb.org/en/stable/guide/async.html
- This PR fixes the issue by making the `RedirectingRouteHandler.get` function asynchronous, by swapping out `requests.get` for tornado's `AsyncHTTPClient.fetch` function.