### PR TITLE
Asynchronous redirecting route handler, GUI version bump

### DIFF
--- a/climb_onyx_gui/handlers.py
+++ b/climb_onyx_gui/handlers.py
@@ -79,7 +79,7 @@ class RedirectingRouteHandler(APIHandler):
                 raise ValidationError("Route is required")
 
             # Request for the Onyx API
-            request = f"{domain.removesuffix('/')}/{route}"
+            request = url_path_join(domain, route)
 
             # Usage of the AsyncHTTPClient is necessary to avoid blocking tornado event loop
             # https://www.tornadoweb.org/en/stable/guide/async.html

--- a/climb_onyx_gui/handlers.py
+++ b/climb_onyx_gui/handlers.py
@@ -78,8 +78,11 @@ class RedirectingRouteHandler(APIHandler):
             if not route:
                 raise ValidationError("Route is required")
 
-            # Make the request to the Onyx API and return the response
+            # Request for the Onyx API
             request = f"{domain.removesuffix('/')}/{route}"
+
+            # Usage of the AsyncHTTPClient is necessary to avoid blocking tornado event loop
+            # https://www.tornadoweb.org/en/stable/guide/async.html
             client = AsyncHTTPClient()
             try:
                 response = await client.fetch(

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@jupyterlab/htmlviewer": "^3.6.1 || ^4.2.1",
         "@jupyterlab/launcher": "^3.6.1 || ^4.0.0",
         "@jupyterlab/services": "^6.6.1 || ^7.0.0",
-        "climb-onyx-gui": "^0.16.2",
+        "climb-onyx-gui": "^0.16.3",
         "react": "^17.0.1 || ^18.2.0",
         "react-dom": "^17.0.1 || ^18.2.0",
         "webpack": "^5.92.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "@jupyterlab/htmlviewer": "^3.6.1 || ^4.2.1",
         "@jupyterlab/launcher": "^3.6.1 || ^4.0.0",
         "@jupyterlab/services": "^6.6.1 || ^7.0.0",
-        "climb-onyx-gui": "^0.16.1",
+        "climb-onyx-gui": "^0.16.2",
         "react": "^17.0.1 || ^18.2.0",
         "react-dom": "^17.0.1 || ^18.2.0",
         "webpack": "^5.92.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "climb-onyx-gui-extension",
-    "version": "0.12.4",
+    "version": "0.12.5",
     "description": "JupyterLab extension for the Onyx Graphical User Interface",
     "keywords": [
         "gui",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "stylelint-config-standard": "^34.0.0",
         "stylelint-csstree-validator": "^3.0.0",
         "stylelint-prettier": "^4.0.0",
-        "typescript": "~5.0.2",
+        "typescript": "~5.7.0",
         "yjs": "^13.5.0"
     },
     "sideEffects": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,7 +2210,7 @@ __metadata:
     "@types/react-addons-linked-state-mixin": ^0.14.22
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    climb-onyx-gui: ^0.16.1
+    climb-onyx-gui: ^0.16.2
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
@@ -2234,9 +2234,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"climb-onyx-gui@npm:^0.16.1":
-  version: 0.16.1
-  resolution: "climb-onyx-gui@npm:0.16.1"
+"climb-onyx-gui@npm:^0.16.2":
+  version: 0.16.2
+  resolution: "climb-onyx-gui@npm:0.16.2"
   dependencies:
     "@ag-grid-community/client-side-row-model": ^32.2.0
     "@ag-grid-community/core": ^32.2.0
@@ -2257,7 +2257,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: dfbbf24fd5fc270a5ecce040840a51083bae87821c61d15918995837b8db363f93559f8d164966002fd6e3bafb09453274accfd765d78e551f3f6faf469d8e79
+  checksum: 37961200fb3e3a15739cccffd57a9daa8eb6daead4ad1da6a1e748c8da250654ef38dc66fbdea2ae7967c2119ce03f4b08431e7cd82e92752ac1516498fa79f2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,7 +2210,7 @@ __metadata:
     "@types/react-addons-linked-state-mixin": ^0.14.22
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
-    climb-onyx-gui: ^0.16.2
+    climb-onyx-gui: ^0.16.3
     css-loader: ^6.7.1
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
@@ -2234,9 +2234,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"climb-onyx-gui@npm:^0.16.2":
-  version: 0.16.2
-  resolution: "climb-onyx-gui@npm:0.16.2"
+"climb-onyx-gui@npm:^0.16.3":
+  version: 0.16.3
+  resolution: "climb-onyx-gui@npm:0.16.3"
   dependencies:
     "@ag-grid-community/client-side-row-model": ^32.2.0
     "@ag-grid-community/core": ^32.2.0
@@ -2257,7 +2257,7 @@ __metadata:
   peerDependencies:
     react: ^17.0.2
     react-dom: ^17.0.2
-  checksum: 37961200fb3e3a15739cccffd57a9daa8eb6daead4ad1da6a1e748c8da250654ef38dc66fbdea2ae7967c2119ce03f4b08431e7cd82e92752ac1516498fa79f2
+  checksum: a79ee24a55dee23d4bd21f0f0fed09b88042456ab8ebbf4bcfedc1f004f1e8ed132ee495dfd227c4c5c95d158c291383ca5f4ddd30678aad4dab65ee43dd4f90
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,7 +2228,7 @@ __metadata:
     stylelint-config-standard: ^34.0.0
     stylelint-csstree-validator: ^3.0.0
     stylelint-prettier: ^4.0.0
-    typescript: ~5.0.2
+    typescript: ~5.7.0
     webpack: ^5.92.0
     yjs: ^13.5.0
   languageName: unknown
@@ -6133,23 +6133,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.0.2":
-  version: 5.0.4
-  resolution: "typescript@npm:5.0.4"
+"typescript@npm:~5.7.0":
+  version: 5.7.3
+  resolution: "typescript@npm:5.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
+  checksum: 6c38b1e989918e576f0307e6ee013522ea480dfce5f3ca85c9b2d8adb1edeffd37f4f30cd68de0c38a44563d12ba922bdb7e36aa2dac9c51de5d561e6e9a2e9c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
-  version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
+"typescript@patch:typescript@~5.7.0#~builtin<compat/typescript>":
+  version: 5.7.3
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#~builtin<compat/typescript>::version=5.7.3&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
+  checksum: 633cd749d6cd7bc842c6b6245847173bba99742a60776fae3c0fbcc0d1733cd51a733995e5f4dadd8afb0e64e57d3c7dbbeae953a072ee303940eca69e22f311
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Using tornado `AsyncHTTPClient` to prevent blocking of Jupyterlab operations in #27 
- Bumped Onyx GUI version to [from v0.16.1 to v0.16.3](https://github.com/CLIMB-TRE/onyx-gui/compare/v0.16.1...v0.16.3).