### PR TITLE
`v0.12.12`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "climb-onyx-gui-extension",
-    "version": "0.12.11",
+    "version": "0.12.12",
     "description": "JupyterLab extension for the Onyx Graphical User Interface",
     "keywords": [
         "gui",

--- a/src/onyxWidget.tsx
+++ b/src/onyxWidget.tsx
@@ -95,11 +95,7 @@ export class OnyxWidget extends ReactWidget {
   // Handler for opening S3 documents
   s3PathHandler = async (uri: string): Promise<void> => {
     const data = await requestAPI<any>('s3', {}, ['uri', uri]);
-    const widget = this.documentManager.open(data['path']);
-    // Trust documents opened by this extension
-    if (widget && 'trusted' in widget.content) {
-      widget.content.trusted = true;
-    }
+    this.documentManager.open(data['path']);
   };
 
   // Handler for writing files


### PR DESCRIPTION
- Per-document trust logic doesn't work - it is being removed entirely for security reasons.